### PR TITLE
deps: Remove unnecessary go patch version from go.mods

### DIFF
--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-go 1.22.7
+go 1.22
 
 require (
 	google.golang.org/grpc v1.65.0

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/examples
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78

--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/gcp/observability
 
-go 1.22.7
+go 1.22
 
 require (
 	cloud.google.com/go/logging v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/observability
 
-go 1.22.7
+go 1.22
 
 require (
 	google.golang.org/grpc v1.67.1

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/xds
 
-go 1.22.7
+go 1.22
 
 replace google.golang.org/grpc => ../..
 

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls/examples
 
-go 1.22.7
+go 1.22
 
 require (
 	google.golang.org/grpc v1.67.1

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/stats/opencensus/go.mod
+++ b/stats/opencensus/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/stats/opencensus
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/test/tools/go.mod
+++ b/test/tools/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/test/tools
 
-go 1.22.7
+go 1.22.1
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
The patch version got added when bumping the go major version from 1.21 to 1.22. Specifying the patch version is not necessary unless the dependencies specify a path version. This PR removes the patch version from all but one go.mod file.

## Why
As mentioned in [this thread](https://github.com/grpc/grpc-go/pull/7624#discussion_r1757159186), grpc-go being a library should not specify a patch version.

RELEASE NOTES: N/A