### PR TITLE
Repro race

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"google.golang.org/grpc/balancer"
@@ -415,6 +416,7 @@ func (b *cdsBalancer) Close() {
 }
 
 func (b *cdsBalancer) ExitIdle() {
+	time.Sleep(50 * time.Millisecond)
 	b.serializer.TrySchedule(func(context.Context) {
 		if b.childLB == nil {
 			b.logger.Warningf("Received ExitIdle with no child policy")

--- a/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
@@ -19,7 +19,9 @@
 package clusterresolver
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -85,6 +87,9 @@ func (er *edsDiscoveryMechanism) OnUpdate(update *xdsresource.EndpointsResourceD
 	er.mu.Lock()
 	er.update = &update.Resource
 	er.mu.Unlock()
+
+	fmt.Println("Introducing fake delay in EDS update")
+	time.Sleep(1 * time.Second)
 
 	er.topLevelResolver.onUpdate(onDone)
 }


### PR DESCRIPTION
Command to run:
```sh
go test ./xds/internal/balancer/clusterresolver/e2e_test/ -count=1  -v -run "Test/ErrorFromParentLB_ConnectionError"
```